### PR TITLE
Fix node.cmd white space paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ function mungeCmd (workingDir, options) {
   var m = command.match(re)
   var replace
   var nodeCmd = workingDir + '/node.cmd'
-  if(workingDir.index(' ') !== -1) {
+  if(workingDir.indexOf(' ') !== -1) {
     nodeCmd = ' "' + nodeCmd + '"'
   }
   if (m) {

--- a/index.js
+++ b/index.js
@@ -150,11 +150,15 @@ function mungeCmd (workingDir, options) {
 
   var m = command.match(re)
   var replace
+  var nodeCmd = workingDir + '/node.cmd'
+  if(workingDir.index(' ') !== -1) {
+    nodeCmd = ' "' + nodeCmd + '"'
+  }
   if (m) {
     options.originalNode = m[2]
     replace = m[1] + workingDir + '/node.cmd' + m[3] + m[4]
     options.args[cmdi + 1] = m[1] + m[2] + m[3] +
-      ' "' + workingDir + '\\node"' + m[4]
+      nodeCmd + m[4]
   } else {
     // XXX probably not a good idea to rewrite to the first npm in the
     // path if it's a full path to npm.  And if it's not a full path to
@@ -165,7 +169,7 @@ function mungeCmd (workingDir, options) {
 
     var npmPath = whichOrUndefined('npm') || 'npm'
     npmPath = path_.dirname(npmPath) + '\\node_modules\\npm\\bin\\npm-cli.js'
-    replace = m[1] + workingDir + '/node.cmd' +
+    replace = m[1] + nodeCmd +
               ' "' + npmPath + '"' +
               m[3] + m[4]
     options.args[cmdi + 1] = command.replace(npmre, replace)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-wrap",
-  "version": "1.3.5",
+  "version": "1.3.5-a",
   "description": "Wrap all spawned Node.js child processes by adding environs and arguments ahead of the main JavaScript file argument.",
   "main": "index.js",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-wrap",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Wrap all spawned Node.js child processes by adding environs and arguments ahead of the main JavaScript file argument.",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
If node.cmd is in a path with white spaces (e.g. nyc run on windows where the user home has a space in it), the command fails with ENOENT. This should fix it.