### PR TITLE
feat: require Node 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.12'
-  - '4'
-  - '5'
-  - '6'
+  - '8'
+  - '10'
+  - '12'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - nodejs_version: '8'
-    - nodejs_version: '6'
-    - nodejs_version: '4'
+    - nodejs_version: '10'
+    - nodejs_version: '12'
 install:
   - ps: Install-Product node $env:nodejs_version
   - npm -g install npm@latest

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.4.2",
   "description": "Wrap all spawned Node.js child processes by adding environs and arguments ahead of the main JavaScript file argument.",
   "main": "index.js",
+  "engines": {
+    "node": ">=8"
+  },
   "dependencies": {
     "foreground-child": "^1.5.6",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
## Why

- Align with Node's support policy by targeting oldest LTS.
- Use promise-based APIs out-of-the box (without having to use bluebird)
- Remove workarounds for old Node versions
- Refactor the internals to use ES syntax (scoped variables, spread args, arrow functions, etc.)

Supporting unmaintained Node versions is proving to be an increasing burden as third party libraries drop support for it (e.g. `tap`). Using ES5 syntax while ES2015 brought a lot of improvements to the language is also a weight on maintenance. Finally, this is a pretty mild breaking change: there is no intent to break API compat. Since it implies a semver major update, it will be opt-in and only affect users explicitly updating their projects. The primary motivations for this PR is improving coverage tools using V8, a feature only present on modern Node versions anyway.

## What

- Update CI to run against the currently supported Node versions: Node 6, 8 and 10.
- Add `engines.node` field to `package.json` to warn users trying to use the library on an unmaintained Node version.

/cc @bcoe @profnandaa