### PR TITLE
fix: Use `is-windows` package for detection

### DIFF
--- a/lib/is-windows.js
+++ b/lib/is-windows.js
@@ -1,5 +1,0 @@
-module.exports = function () {
-  return process.platform === 'win32' ||
-    process.env.OSTYPE === 'cygwin' ||
-    process.env.OSTYPE === 'msys'
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1558,6 +1558,11 @@
       "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
       "dev": true
     },
+    "is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "dependencies": {
     "foreground-child": "^1.5.6",
+    "is-windows": "^1.0.2",
     "mkdirp": "^0.5.0",
     "os-homedir": "^1.0.1",
     "rimraf": "^2.6.2",
@@ -36,8 +37,7 @@
   },
   "files": [
     "index.js",
-    "shim.js",
-    "lib/is-windows.js"
+    "shim.js"
   ],
   "tap": {
     "coverage": false,

--- a/shim.js
+++ b/shim.js
@@ -45,6 +45,7 @@
 
   const settings = require('./settings.json')
   const foregroundChild = require(settings.deps.foregroundChild)
+  const IS_WINDOWS = settings.isWindows
   const argv = settings.argv
   const nargs = argv.length
   const env = settings.env
@@ -148,14 +149,7 @@
 
   // Unwrap the PATH environment var so that we're not mucking
   // with the environment.  It'll get re-added if they spawn anything
-  const isWindows = (
-    // TODO: Use `lib/is-windows`
-    process.platform === 'win32' ||
-    process.env.OSTYPE === 'cygwin' ||
-    process.env.OSTYPE === 'msys'
-  )
-
-  if (isWindows) {
+  if (IS_WINDOWS) {
     for (const i in process.env) {
       if (/^path$/i.test(i)) {
         process.env[i] = process.env[i].replace(__dirname + ';', '')

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,7 +1,7 @@
 var sw = require('../')
-var isWindows = require('../lib/is-windows.js')()
-var winNoShebang = isWindows && 'no shebang execution on windows'
-var winNoSig = isWindows && 'no signals get through cmd'
+var IS_WINDOWS = require('is-windows')()
+var winNoShebang = IS_WINDOWS && 'no shebang execution on windows'
+var winNoSig = IS_WINDOWS && 'no signals get through cmd'
 
 var onExit = require('signal-exit')
 var cp = require('child_process')
@@ -196,7 +196,7 @@ t.test('exec execPath', function (t) {
   t.plan(4)
 
   t.test('basic', function (t) {
-    var opt = isWindows ? null : { shell: '/bin/bash' }
+    var opt = IS_WINDOWS ? null : { shell: '/bin/bash' }
     var child = cp.exec('"' + process.execPath + '" "' + fixture + '" xyz', opt)
 
     var out = ''
@@ -212,7 +212,7 @@ t.test('exec execPath', function (t) {
   })
 
   t.test('execPath wrapped with quotes', function (t) {
-    var opt = isWindows ? null : { shell: '/bin/bash' }
+    var opt = IS_WINDOWS ? null : { shell: '/bin/bash' }
     var child = cp.exec(JSON.stringify(process.execPath) + ' ' + fixture +
       ' xyz', opt)
 


### PR DESCRIPTION
This commit replaces the vendored `lib/is-windows` module by the `is-windows` package.

- Closes tapjs/spawn-wrap#61