### PR TITLE
chore: Refactor library to use smaller modules

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,8 +15,8 @@ const rimraf = require('rimraf')
 const path = require('path')
 const signalExit = require('signal-exit')
 const {IS_DEBUG, debug} = require("./lib/debug")
-const {munge} = require("./lib/munge")
-const {homedir} = require("./lib/homedir")
+const munge = require("./lib/munge")
+const homedir = require("./lib/homedir")
 
 const shebang = process.platform === 'os390' ?
   '#!/bin/env ' : '#!'

--- a/index.js
+++ b/index.js
@@ -123,11 +123,9 @@ function setup(argv, env) {
     root: process.pid
   }, null, 2) + '\n'
 
-  signalExit(function () {
-    if (!IS_DEBUG) {
-      rimraf.sync(workingDir)
-    }
-  })
+  if (!IS_DEBUG) {
+    signalExit(() => rimraf.sync(workingDir))
+  }
 
   mkdirp.sync(workingDir)
   workingDir = fs.realpathSync(workingDir)

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 module.exports = wrap
 wrap.runMain = runMain
 
@@ -12,22 +14,9 @@ const mkdirp = require('mkdirp')
 const rimraf = require('rimraf')
 const path = require('path')
 const signalExit = require('signal-exit')
-const home = process.env.SPAWN_WRAP_SHIM_ROOT || require('os-homedir')()
-const homedir = home + '/.node-spawn-wrap-'
-const which = require('which')
-const util = require('util')
-
-const doDebug = process.env.SPAWN_WRAP_DEBUG === '1'
-
-function debug () {
-  if (!doDebug) {
-    return
-  }
-  const prefix = 'SW ' + process.pid + ': '
-  const data = util.format.apply(util, arguments).trim()
-  const message = prefix + data.split('\n').join('\n' + prefix)
-  process.stderr.write(message + '\n')
-}
+const {IS_DEBUG, debug} = require("./lib/debug")
+const {munge} = require("./lib/munge")
+const {homedir} = require("./lib/homedir")
 
 const shebang = process.platform === 'os390' ?
   '#!/bin/env ' : '#!'
@@ -35,11 +24,7 @@ const shebang = process.platform === 'os390' ?
 const shim = shebang + process.execPath + '\n' +
   fs.readFileSync(path.join(__dirname, 'shim.js'))
 
-const pathRe = IS_WINDOWS ? /^PATH=/i : /^PATH=/
-
-const colon = IS_WINDOWS ? ';' : ':'
-
-function wrap (argv, env, workingDir) {
+function wrap(argv, env, workingDir) {
   const spawnSyncBinding = process.binding('spawn_sync')
 
   // if we're passed in the working dir, then it means that setup
@@ -52,7 +37,7 @@ function wrap (argv, env, workingDir) {
   const spawnSync = spawnSyncBinding.spawn
 
   function unwrap() {
-    if (doSetup && !doDebug) {
+    if (doSetup && !IS_DEBUG) {
       rimraf.sync(workingDir)
     }
     ChildProcess.prototype.spawn = spawn
@@ -75,266 +60,7 @@ function wrappedSpawnFunction (fn, workingDir) {
   }
 }
 
-function isSh (file) {
-  return file === 'dash' ||
-         file === 'sh' ||
-         file === 'bash' ||
-         file === 'zsh'
-}
-
-function mungeSh (workingDir, options) {
-  const cmdi = options.args.indexOf('-c')
-  if (cmdi === -1) {
-    return // no -c argument
-  }
-
-  let c = options.args[cmdi + 1]
-  const re = /^\s*((?:[^\= ]*\=[^\=\s]*)*[\s]*)([^\s]+|"[^"]+"|'[^']+')( .*)?$/
-  const match = c.match(re)
-  if (match === null) {
-    return // not a command invocation.  weird but possible
-  }
-
-  let command = match[2]
-  // strip quotes off the command
-  const quote = command.charAt(0)
-  if ((quote === '"' || quote === '\'') && quote === command.slice(-1)) {
-    command = command.slice(1, -1)
-  }
-  const exe = path.basename(command)
-
-  if (isNode(exe)) {
-    options.originalNode = command
-    c = match[1] + match[2] + ' "' + workingDir + '/node" ' + match[3]
-    options.args[cmdi + 1] = c
-  } else if (exe === 'npm' && !IS_WINDOWS) {
-    // XXX this will exhibit weird behavior when using /path/to/npm,
-    // if some other npm is first in the path.
-    const npmPath = whichOrUndefined('npm')
-
-    if (npmPath) {
-      c = c.replace(re, '$1 "' + workingDir + '/node" "' + npmPath + '" $3')
-      options.args[cmdi + 1] = c
-      debug('npm munge!', c)
-    }
-  }
-}
-
-function isCmd (file) {
-  const comspec = path.basename(process.env.comspec || '').replace(/\.exe$/i, '')
-  return IS_WINDOWS && (file === comspec || /^cmd(?:\.exe)?$/i.test(file))
-}
-
-function mungeCmd(workingDir, options) {
-  const cmdi = options.args.indexOf('/c')
-  if (cmdi === -1) {
-    return
-  }
-
-  const re = /^\s*("*)([^"]*?\bnode(?:\.exe|\.EXE)?)("*)( .*)?$/
-  const npmre = /^\s*("*)([^"]*?\b(?:npm))("*)( |$)/
-
-  const command = options.args[cmdi + 1]
-  if (command === undefined) {
-    return
-  }
-
-  let m = command.match(re)
-  let replace
-  if (m) {
-    options.originalNode = m[2]
-    replace = m[1] + workingDir + '/node.cmd' + m[3] + m[4]
-    options.args[cmdi + 1] = m[1] + m[2] + m[3] +
-      ' "' + workingDir + '\\node"' + m[4]
-  } else {
-    // XXX probably not a good idea to rewrite to the first npm in the
-    // path if it's a full path to npm.  And if it's not a full path to
-    // npm, then the dirname will not work properly!
-    m = command.match(npmre)
-    if (m === null) {
-      return
-    }
-
-    let npmPath = whichOrUndefined('npm') || 'npm'
-    npmPath = path.dirname(npmPath) + '\\node_modules\\npm\\bin\\npm-cli.js'
-    replace = m[1] + workingDir + '/node.cmd' +
-      ' "' + npmPath + '"' +
-      m[3] + m[4]
-    options.args[cmdi + 1] = command.replace(npmre, replace)
-  }
-}
-
-function isNode (file) {
-  const cmdname = path.basename(process.execPath).replace(/\.exe$/i, '')
-  return file === 'node' || cmdname === file
-}
-
-function mungeNode (workingDir, options) {
-  options.originalNode = options.file
-  const command = path.basename(options.file).replace(/\.exe$/i, '')
-  // make sure it has a main script.
-  // otherwise, just let it through.
-  let a = 0
-  let hasMain = false
-  let mainIndex = 1
-  for (a = 1; !hasMain && a < options.args.length; a++) {
-    switch (options.args[a]) {
-      case '-p':
-      case '-i':
-      case '--interactive':
-      case '--eval':
-      case '-e':
-      case '-pe':
-        hasMain = false
-        a = options.args.length
-        continue
-
-      case '-r':
-      case '--require':
-        a += 1
-        continue
-
-      default:
-        if (options.args[a].match(/^-/)) {
-          continue
-        } else {
-          hasMain = true
-          mainIndex = a
-          a = options.args.length
-          break
-        }
-    }
-  }
-
-  if (hasMain) {
-    const replace = workingDir + '/' + command
-    options.args.splice(mainIndex, 0, replace)
-  }
-
-  // If the file is just something like 'node' then that'll
-  // resolve to our shim, and so to prevent double-shimming, we need
-  // to resolve that here first.
-  // This also handles the case where there's not a main file, like
-  // `node -e 'program'`, where we want to avoid the shim entirely.
-  if (options.file === options.basename) {
-    const realNode = whichOrUndefined(options.file) || process.execPath
-    options.file = options.args[0] = realNode
-  }
-
-  debug('mungeNode after', options.file, options.args)
-}
-
-function mungeShebang (workingDir, options) {
-  let resolved
-  try {
-    resolved = which.sync(options.file)
-  } catch (err) {
-    // nothing to do if we can't resolve
-    // Most likely: file doesn't exist or is not executable.
-    // Let exec pass through, probably will fail, oh well.
-    return
-  }
-
-  const shebang = fs.readFileSync(resolved, 'utf8')
-  const match = shebang.match(/^#!([^\r\n]+)/)
-  if (!match) {
-    return // not a shebang script, probably a binary
-  }
-
-  const shebangbin = match[1].split(' ')[0]
-  const maybeNode = path.basename(shebangbin)
-  if (!isNode(maybeNode)) {
-    return // not a node shebang, leave untouched
-  }
-
-  options.originalNode = shebangbin
-  options.basename = maybeNode
-  options.file = shebangbin
-  options.args = [shebangbin, workingDir + '/' + maybeNode]
-    .concat(resolved)
-    .concat(match[1].split(' ').slice(1))
-    .concat(options.args.slice(1))
-}
-
-function mungeEnv (workingDir, options) {
-  let pathEnv
-  for (let i = 0; i < options.envPairs.length; i++) {
-    const ep = options.envPairs[i]
-    if (pathRe.test(ep)) {
-      pathEnv = ep.substr(5)
-      const k = ep.substr(0, 5)
-      options.envPairs[i] = k + workingDir + colon + pathEnv
-    }
-  }
-  if (pathEnv === undefined) {
-    options.envPairs.push((IS_WINDOWS ? 'Path=' : 'PATH=') + workingDir)
-  }
-  if (options.originalNode) {
-    const key = path.basename(workingDir).substr('.node-spawn-wrap-'.length)
-    options.envPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
-  }
-
-  options.envPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
-
-  if (process.env.SPAWN_WRAP_DEBUG === '1') {
-    options.envPairs.push('SPAWN_WRAP_DEBUG=1')
-  }
-}
-
-function isnpm (file) {
-  // XXX is this even possible/necessary?
-  // wouldn't npm just be detected as a node shebang?
-  return file === 'npm' && !IS_WINDOWS
-}
-
-function mungenpm (workingDir, options) {
-  debug('munge npm')
-  // XXX weird effects of replacing a specific npm with a global one
-  const npmPath = whichOrUndefined('npm')
-
-  if (npmPath !== undefined) {
-    options.args[0] = npmPath
-
-    options.file = workingDir + '/node'
-    options.args.unshift(workingDir + '/node')
-  }
-}
-
-function munge (workingDir, options) {
-  options.basename = path.basename(options.file).replace(/\.exe$/i, '')
-
-  // XXX: dry this
-  if (isSh(options.basename)) {
-    mungeSh(workingDir, options)
-  } else if (isCmd(options.basename)) {
-    mungeCmd(workingDir, options)
-  } else if (isNode(options.basename)) {
-    mungeNode(workingDir, options)
-  } else if (isnpm(options.basename)) {
-    // XXX unnecessary?  on non-windows, npm is just another shebang
-    mungenpm(workingDir, options)
-  } else {
-    mungeShebang(workingDir, options)
-  }
-
-  // now the options are munged into shape.
-  // whether we changed something or not, we still update the PATH
-  // so that if a script somewhere calls `node foo`, it gets our
-  // wrapper instead.
-
-  mungeEnv(workingDir, options)
-}
-
-function whichOrUndefined (executable) {
-  let path
-  try {
-    path = which.sync(executable)
-  } catch (er) {
-  }
-  return path
-}
-
-function setup (argv, env) {
+function setup(argv, env) {
   if (argv && typeof argv === 'object' && !env && !Array.isArray(argv)) {
     env = argv
     argv = []
@@ -398,7 +124,7 @@ function setup (argv, env) {
   }, null, 2) + '\n'
 
   signalExit(function () {
-    if (!doDebug) {
+    if (!IS_DEBUG) {
       rimraf.sync(workingDir)
     }
   })

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const util = require('util');
+
 /**
  * Boolean indicating if debug mode is enabled.
  *

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * Boolean indicating if debug mode is enabled.
+ *
+ * @type {boolean}
+ */
+const IS_DEBUG = process.env.SPAWN_WRAP_DEBUG === '1'
+
+/**
+ * If debug is enabled, write message to stderr.
+ *
+ * If debug is disabled, no message is written.
+ */
+function debug() {
+  if (!IS_DEBUG) {
+    return;
+  }
+  const prefix = 'SW ' + process.pid + ': '
+  const data = util.format.apply(util, arguments).trim()
+  const message = prefix + data.split('\n').join('\n' + prefix)
+  process.stderr.write(message + '\n')
+}
+
+module.exports = {
+  IS_DEBUG,
+  debug,
+}

--- a/lib/debug.js
+++ b/lib/debug.js
@@ -14,12 +14,12 @@ const IS_DEBUG = process.env.SPAWN_WRAP_DEBUG === '1'
  *
  * If debug is disabled, no message is written.
  */
-function debug() {
+function debug(...args) {
   if (!IS_DEBUG) {
     return;
   }
   const prefix = 'SW ' + process.pid + ': '
-  const data = util.format.apply(util, arguments).trim()
+  const data = util.format.apply(util, ...args).trim()
   const message = prefix + data.split('\n').join('\n' + prefix)
   process.stderr.write(message + '\n')
 }

--- a/lib/exe-type.js
+++ b/lib/exe-type.js
@@ -19,10 +19,8 @@ function isNpm(file) {
   return file === 'npm' && !isWindows()
 }
 
-const KNOWN_SHELLS = new Set(['dash', 'sh', 'bash', 'zsh'])
-
 function isSh(file) {
-  return KNOWN_SHELLS.has(file)
+  return ['dash', 'sh', 'bash', 'zsh'].includes(file)
 }
 
 module.exports = {

--- a/lib/exe-type.js
+++ b/lib/exe-type.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const isWindows = require("is-windows")
+const path = require("path")
+
+function isCmd(file) {
+  const comspec = path.basename(process.env.comspec || '').replace(/\.exe$/i, '')
+  return isWindows() && (file === comspec || /^cmd(?:\.exe)?$/i.test(file))
+}
+
+function isNode(file) {
+  const cmdname = path.basename(process.execPath).replace(/\.exe$/i, '')
+  return file === 'node' || cmdname === file
+}
+
+function isNpm(file) {
+  // XXX is this even possible/necessary?
+  // wouldn't npm just be detected as a node shebang?
+  return file === 'npm' && !isWindows()
+}
+
+const KNOWN_SHELLS = new Set(['dash', 'sh', 'bash', 'zsh'])
+
+function isSh(file) {
+  return KNOWN_SHELLS.has(file)
+}
+
+module.exports = {
+  isCmd,
+  isNode,
+  isNpm,
+  isSh,
+}

--- a/lib/homedir.js
+++ b/lib/homedir.js
@@ -1,0 +1,10 @@
+'use strict'
+
+const osHomedir = require('os-homedir')
+
+const home = process.env.SPAWN_WRAP_SHIM_ROOT || osHomedir()
+const homedir = home + '/.node-spawn-wrap-'
+
+module.exports = {
+  homedir
+}

--- a/lib/homedir.js
+++ b/lib/homedir.js
@@ -1,8 +1,8 @@
 'use strict'
 
-const osHomedir = require('os-homedir')
+const os = require('os')
 
-const home = process.env.SPAWN_WRAP_SHIM_ROOT || osHomedir()
+const home = process.env.SPAWN_WRAP_SHIM_ROOT || os.homedir()
 const homedir = home + '/.node-spawn-wrap-'
 
 module.exports = {

--- a/lib/homedir.js
+++ b/lib/homedir.js
@@ -5,6 +5,4 @@ const os = require('os')
 const home = process.env.SPAWN_WRAP_SHIM_ROOT || os.homedir()
 const homedir = home + '/.node-spawn-wrap-'
 
-module.exports = {
-  homedir
-}
+module.exports = homedir

--- a/lib/munge.js
+++ b/lib/munge.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const path = require("path")
+const {isCmd, isNode, isNpm, isSh} = require("./exe-type")
+const {mungeCmd} = require("./mungers/cmd")
+const {mungeEnv} = require("./mungers/env")
+const {mungeNode} = require("./mungers/node")
+const {mungeNpm} = require("./mungers/npm")
+const {mungeSh} = require("./mungers/sh")
+const {mungeShebang} = require("./mungers/shebang")
+
+function munge(workingDir, options) {
+  options.basename = path.basename(options.file).replace(/\.exe$/i, '')
+
+  // XXX: dry this
+  if (isSh(options.basename)) {
+    mungeSh(workingDir, options)
+  } else if (isCmd(options.basename)) {
+    mungeCmd(workingDir, options)
+  } else if (isNode(options.basename)) {
+    mungeNode(workingDir, options)
+  } else if (isNpm(options.basename)) {
+    // XXX unnecessary?  on non-windows, npm is just another shebang
+    mungeNpm(workingDir, options)
+  } else {
+    mungeShebang(workingDir, options)
+  }
+
+  // now the options are munged into shape.
+  // whether we changed something or not, we still update the PATH
+  // so that if a script somewhere calls `node foo`, it gets our
+  // wrapper instead.
+
+  mungeEnv(workingDir, options)
+}
+
+module.exports = {
+  munge,
+}

--- a/lib/munge.js
+++ b/lib/munge.js
@@ -2,12 +2,12 @@
 
 const path = require("path")
 const {isCmd, isNode, isNpm, isSh} = require("./exe-type")
-const {mungeCmd} = require("./mungers/cmd")
-const {mungeEnv} = require("./mungers/env")
-const {mungeNode} = require("./mungers/node")
-const {mungeNpm} = require("./mungers/npm")
-const {mungeSh} = require("./mungers/sh")
-const {mungeShebang} = require("./mungers/shebang")
+const mungeCmd = require("./mungers/cmd")
+const mungeEnv = require("./mungers/env")
+const mungeNode = require("./mungers/node")
+const mungeNpm = require("./mungers/npm")
+const mungeSh = require("./mungers/sh")
+const mungeShebang = require("./mungers/shebang")
 
 function munge(workingDir, options) {
   options.basename = path.basename(options.file).replace(/\.exe$/i, '')
@@ -34,6 +34,4 @@ function munge(workingDir, options) {
   mungeEnv(workingDir, options)
 }
 
-module.exports = {
-  munge,
-}
+module.exports = munge

--- a/lib/mungers/cmd.js
+++ b/lib/mungers/cmd.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const path = require("path")
+const {whichOrUndefined} = require("../which-or-undefined")
+
+function mungeCmd(workingDir, options) {
+  const cmdi = options.args.indexOf('/c')
+  if (cmdi === -1) {
+    return
+  }
+
+  const re = /^\s*("*)([^"]*?\bnode(?:\.exe|\.EXE)?)("*)( .*)?$/
+  const npmre = /^\s*("*)([^"]*?\b(?:npm))("*)( |$)/
+
+  const command = options.args[cmdi + 1]
+  if (command === undefined) {
+    return
+  }
+
+  let m = command.match(re)
+  let replace
+  if (m) {
+    options.originalNode = m[2]
+    // TODO: Remove `replace`: seems unused
+    replace = m[1] + workingDir + '/node.cmd' + m[3] + m[4]
+    options.args[cmdi + 1] = m[1] + m[2] + m[3] +
+      ' "' + workingDir + '\\node"' + m[4]
+  } else {
+    // XXX probably not a good idea to rewrite to the first npm in the
+    // path if it's a full path to npm.  And if it's not a full path to
+    // npm, then the dirname will not work properly!
+    m = command.match(npmre)
+    if (m === null) {
+      return
+    }
+
+    let npmPath = whichOrUndefined('npm') || 'npm'
+    npmPath = path.dirname(npmPath) + '\\node_modules\\npm\\bin\\npm-cli.js'
+    replace = m[1] + workingDir + '/node.cmd' +
+      ' "' + npmPath + '"' +
+      m[3] + m[4]
+    options.args[cmdi + 1] = command.replace(npmre, replace)
+  }
+}
+
+module.exports = {
+  mungeCmd,
+}

--- a/lib/mungers/cmd.js
+++ b/lib/mungers/cmd.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const path = require("path")
-const {whichOrUndefined} = require("../which-or-undefined")
+const whichOrUndefined = require("../which-or-undefined")
 
 function mungeCmd(workingDir, options) {
   const cmdi = options.args.indexOf('/c')
@@ -43,6 +43,4 @@ function mungeCmd(workingDir, options) {
   }
 }
 
-module.exports = {
-  mungeCmd,
-}
+module.exports = mungeCmd

--- a/lib/mungers/env.js
+++ b/lib/mungers/env.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const isWindows = require("is-windows")
+const path = require("path")
+const {homedir} = require("../homedir")
+
+const pathRe = isWindows() ? /^PATH=/i : /^PATH=/;
+const colon = isWindows() ? ';' : ':'
+
+function mungeEnv(workingDir, options) {
+  let pathEnv
+  for (let i = 0; i < options.envPairs.length; i++) {
+    const ep = options.envPairs[i]
+    if (pathRe.test(ep)) {
+      pathEnv = ep.substr(5)
+      const k = ep.substr(0, 5)
+      options.envPairs[i] = k + workingDir + colon + pathEnv
+    }
+  }
+  if (pathEnv === undefined) {
+    options.envPairs.push((isWindows() ? 'Path=' : 'PATH=') + workingDir)
+  }
+  if (options.originalNode) {
+    const key = path.basename(workingDir).substr('.node-spawn-wrap-'.length)
+    options.envPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
+  }
+
+  options.envPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
+
+  if (process.env.SPAWN_WRAP_DEBUG === '1') {
+    options.envPairs.push('SPAWN_WRAP_DEBUG=1')
+  }
+}
+
+module.exports = {
+  mungeEnv,
+}

--- a/lib/mungers/env.js
+++ b/lib/mungers/env.js
@@ -2,7 +2,7 @@
 
 const isWindows = require("is-windows")
 const path = require("path")
-const {homedir} = require("../homedir")
+const homedir = require("../homedir")
 
 const pathRe = isWindows() ? /^PATH=/i : /^PATH=/;
 const colon = isWindows() ? ';' : ':'
@@ -32,6 +32,4 @@ function mungeEnv(workingDir, options) {
   }
 }
 
-module.exports = {
-  mungeEnv,
-}
+module.exports = mungeEnv

--- a/lib/mungers/node.js
+++ b/lib/mungers/node.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const path = require('path')
+const {debug} = require("../debug")
+const {whichOrUndefined} = require("../which-or-undefined")
+
+
+function mungeNode(workingDir, options) {
+  options.originalNode = options.file
+  const command = path.basename(options.file).replace(/\.exe$/i, '')
+  // make sure it has a main script.
+  // otherwise, just let it through.
+  let a = 0
+  let hasMain = false
+  let mainIndex = 1
+  for (a = 1; !hasMain && a < options.args.length; a++) {
+    switch (options.args[a]) {
+      case '-p':
+      case '-i':
+      case '--interactive':
+      case '--eval':
+      case '-e':
+      case '-pe':
+        hasMain = false
+        a = options.args.length
+        continue
+
+      case '-r':
+      case '--require':
+        a += 1
+        continue
+
+      default:
+        // TODO: Double-check this part
+        if (options.args[a].match(/^-/)) {
+          continue
+        } else {
+          hasMain = true
+          mainIndex = a
+          a = options.args.length
+          break
+        }
+    }
+  }
+
+  if (hasMain) {
+    const replace = workingDir + '/' + command
+    options.args.splice(mainIndex, 0, replace)
+  }
+
+  // If the file is just something like 'node' then that'll
+  // resolve to our shim, and so to prevent double-shimming, we need
+  // to resolve that here first.
+  // This also handles the case where there's not a main file, like
+  // `node -e 'program'`, where we want to avoid the shim entirely.
+  if (options.file === options.basename) {
+    const realNode = whichOrUndefined(options.file) || process.execPath
+    options.file = options.args[0] = realNode
+  }
+
+  debug('mungeNode after', options.file, options.args)
+}
+
+module.exports = {
+  mungeNode,
+};

--- a/lib/mungers/node.js
+++ b/lib/mungers/node.js
@@ -2,8 +2,7 @@
 
 const path = require('path')
 const {debug} = require("../debug")
-const {whichOrUndefined} = require("../which-or-undefined")
-
+const whichOrUndefined = require("../which-or-undefined")
 
 function mungeNode(workingDir, options) {
   options.originalNode = options.file
@@ -61,6 +60,4 @@ function mungeNode(workingDir, options) {
   debug('mungeNode after', options.file, options.args)
 }
 
-module.exports = {
-  mungeNode,
-};
+module.exports = mungeNode

--- a/lib/mungers/npm.js
+++ b/lib/mungers/npm.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const path = require("path")
+const {debug} = require("../debug")
+const {whichOrUndefined} = require("../which-or-undefined")
+
+function mungeNpm(workingDir, options) {
+  debug('munge npm')
+  // XXX weird effects of replacing a specific npm with a global one
+  const npmPath = whichOrUndefined('npm')
+
+  if (npmPath !== undefined) {
+    options.args[0] = npmPath
+
+    const file = path.join(workingDir, 'node')
+    options.file = file
+    options.args.unshift(file)
+  }
+}
+
+module.exports = {
+  mungeNpm,
+}

--- a/lib/mungers/npm.js
+++ b/lib/mungers/npm.js
@@ -2,7 +2,7 @@
 
 const path = require("path")
 const {debug} = require("../debug")
-const {whichOrUndefined} = require("../which-or-undefined")
+const whichOrUndefined = require("../which-or-undefined")
 
 function mungeNpm(workingDir, options) {
   debug('munge npm')
@@ -18,6 +18,4 @@ function mungeNpm(workingDir, options) {
   }
 }
 
-module.exports = {
-  mungeNpm,
-}
+module.exports = mungeNpm

--- a/lib/mungers/sh.js
+++ b/lib/mungers/sh.js
@@ -4,7 +4,7 @@ const isWindows = require("is-windows")
 const path = require("path")
 const {debug} = require("../debug")
 const {isNode} = require("../exe-type")
-const {whichOrUndefined} = require("../which-or-undefined")
+const whichOrUndefined = require("../which-or-undefined")
 
 function mungeSh(workingDir, options) {
   const cmdi = options.args.indexOf('-c')
@@ -44,6 +44,4 @@ function mungeSh(workingDir, options) {
   }
 }
 
-module.exports = {
-  mungeSh,
-}
+module.exports = mungeSh

--- a/lib/mungers/sh.js
+++ b/lib/mungers/sh.js
@@ -1,0 +1,49 @@
+'use strict';
+
+const isWindows = require("is-windows")
+const path = require("path")
+const {debug} = require("../debug")
+const {isNode} = require("../exe-type")
+const {whichOrUndefined} = require("../which-or-undefined")
+
+function mungeSh(workingDir, options) {
+  const cmdi = options.args.indexOf('-c')
+  if (cmdi === -1) {
+    return // no -c argument
+  }
+
+  let c = options.args[cmdi + 1]
+  const re = /^\s*((?:[^\= ]*\=[^\=\s]*)*[\s]*)([^\s]+|"[^"]+"|'[^']+')( .*)?$/
+  const match = c.match(re)
+  if (match === null) {
+    return // not a command invocation.  weird but possible
+  }
+
+  let command = match[2]
+  // strip quotes off the command
+  const quote = command.charAt(0)
+  if ((quote === '"' || quote === '\'') && quote === command.slice(-1)) {
+    command = command.slice(1, -1)
+  }
+  const exe = path.basename(command)
+
+  if (isNode(exe)) {
+    options.originalNode = command
+    c = match[1] + match[2] + ' "' + workingDir + '/node" ' + match[3]
+    options.args[cmdi + 1] = c
+  } else if (exe === 'npm' && !isWindows()) {
+    // XXX this will exhibit weird behavior when using /path/to/npm,
+    // if some other npm is first in the path.
+    const npmPath = whichOrUndefined('npm')
+
+    if (npmPath) {
+      c = c.replace(re, '$1 "' + workingDir + '/node" "' + npmPath + '" $3')
+      options.args[cmdi + 1] = c
+      debug('npm munge!', c)
+    }
+  }
+}
+
+module.exports = {
+  mungeSh,
+}

--- a/lib/mungers/shebang.js
+++ b/lib/mungers/shebang.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const fs = require("fs")
+const path = require("path")
+const {isNode} = require("../exe-type")
+const {whichOrUndefined} = require("../which-or-undefined")
+
+function mungeShebang(workingDir, options) {
+  const resolved = whichOrUndefined(options.file)
+  if (resolved === undefined) {
+    return
+  }
+
+  const shebang = fs.readFileSync(resolved, 'utf8')
+  const match = shebang.match(/^#!([^\r\n]+)/)
+  if (!match) {
+    return // not a shebang script, probably a binary
+  }
+
+  const shebangbin = match[1].split(' ')[0]
+  const maybeNode = path.basename(shebangbin)
+  if (!isNode(maybeNode)) {
+    return // not a node shebang, leave untouched
+  }
+
+  options.originalNode = shebangbin
+  options.basename = maybeNode
+  options.file = shebangbin
+  options.args = [shebangbin, workingDir + '/' + maybeNode]
+    .concat(resolved)
+    .concat(match[1].split(' ').slice(1))
+    .concat(options.args.slice(1))
+}
+
+module.exports = {
+  mungeShebang,
+}

--- a/lib/mungers/shebang.js
+++ b/lib/mungers/shebang.js
@@ -3,7 +3,7 @@
 const fs = require("fs")
 const path = require("path")
 const {isNode} = require("../exe-type")
-const {whichOrUndefined} = require("../which-or-undefined")
+const whichOrUndefined = require("../which-or-undefined")
 
 function mungeShebang(workingDir, options) {
   const resolved = whichOrUndefined(options.file)
@@ -32,6 +32,4 @@ function mungeShebang(workingDir, options) {
     .concat(options.args.slice(1))
 }
 
-module.exports = {
-  mungeShebang,
-}
+module.exports = mungeShebang

--- a/lib/which-or-undefined.js
+++ b/lib/which-or-undefined.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const which = require("which")
+
+function whichOrUndefined(executable) {
+  let path
+  try {
+    path = which.sync(executable)
+  } catch (err) {
+  }
+  return path
+}
+
+module.exports = {
+  whichOrUndefined
+}

--- a/lib/which-or-undefined.js
+++ b/lib/which-or-undefined.js
@@ -11,6 +11,4 @@ function whichOrUndefined(executable) {
   return path
 }
 
-module.exports = {
-  whichOrUndefined
-}
+module.exports = whichOrUndefined

--- a/package-lock.json
+++ b/package-lock.json
@@ -834,9 +834,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -2045,9 +2045,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "nested-error-stacks": {
@@ -2192,7 +2192,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "3.1.0",
@@ -2848,9 +2849,9 @@
       "dev": true
     },
     "tap": {
-      "version": "13.1.6",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.6.tgz",
-      "integrity": "sha512-pgFbhB3dzw+3mR/8kfytoAxxD8Qkdn8OiwEccjn6RnbhQrxOrgMWaRVwtMLD6AT5bD4AWye1fnGHP2L5d4hzVw==",
+      "version": "13.1.8",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.8.tgz",
+      "integrity": "sha512-WimjKgEZPOxSufS6Vfo/ACQmfMdLGmrIi9ZL6Q1mZpHcbdnBP4DgdIJWM+PKrLS4sbrIN2trKKlNO0QkziE1EQ==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^1.1.0",
@@ -2885,7 +2886,7 @@
         "tap-mocha-reporter": "^4.0.1",
         "tap-parser": "^9.3.2",
         "tap-yaml": "^1.0.0",
-        "tcompare": "^2.2.0",
+        "tcompare": "^2.3.0",
         "treport": "^0.3.0",
         "trivial-deferred": "^1.0.1",
         "ts-node": "^8.1.0",
@@ -2953,9 +2954,9 @@
       }
     },
     "tcompare": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-2.2.0.tgz",
-      "integrity": "sha512-+Mr0UBIE3ncNn0wJvKsw8ph61QoaDvR6Q8WkxWIHxWLcKf8SHGyTTkGLMX//4NKQ/Pe1Uu64oXYJsxLyAXXWdA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tcompare/-/tcompare-2.3.0.tgz",
+      "integrity": "sha512-fAfA73uFtFGybWGt4+IYT6UPLYVZQ4NfsP+IXEZGY0vh8e2IF7LVKafcQNMRBLqP0wzEA65LM9Tqj+FSmO8GLw==",
       "dev": true
     },
     "test-exclude": {
@@ -3122,9 +3123,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.11.tgz",
-      "integrity": "sha512-izPJg8RsSyqxbdnqX36ExpbH3K7tDBsAU/VfNv89VkMFy3z39zFjunQGsSHOlGlyIfGLGprGeosgQno3bo2/Kg==",
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
+      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -3297,12 +3298,12 @@
       "dev": true
     },
     "yargs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "version": "13.2.4",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.4.tgz",
+      "integrity": "sha512-HG/DWAJa1PAnHT9JAhNa8AbAv3FPaiLzioSjCcmuXXhP8MlpHO5vwls4g4j6n30Z74GVQj8Xa62dWVx1QCGklg==",
       "dev": true,
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
         "os-locale": "^3.1.0",
@@ -3312,7 +3313,7 @@
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.0.0"
+        "yargs-parser": "^13.1.0"
       },
       "dependencies": {
         "ansi-regex": {
@@ -3320,6 +3321,26 @@
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
           "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
           "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "cliui": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
+          "dev": true,
+          "requires": {
+            "string-width": "^3.1.0",
+            "strip-ansi": "^5.2.0",
+            "wrap-ansi": "^5.1.0"
+          }
         },
         "string-width": {
           "version": "3.1.0",
@@ -3339,6 +3360,17 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^4.1.0"
+          }
+        },
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "foreground-child": "^1.5.6",
     "is-windows": "^1.0.2",
     "mkdirp": "^0.5.0",
-    "os-homedir": "^1.0.1",
     "rimraf": "^2.6.2",
     "signal-exit": "^3.0.2",
     "which": "^1.3.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "tap": "^13.1.6"
   },
   "files": [
+    "lib/",
     "index.js",
     "shim.js"
   ],

--- a/test/abs-shebang.js
+++ b/test/abs-shebang.js
@@ -6,7 +6,6 @@ var node = process.execPath
 var wrap = require.resolve('./fixtures/wrap.js')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')
-var fs = require('fs')
 
 if (process.platform === 'win32') {
   t.plan(0, 'No proper shebang support on windows, so skip this')


### PR DESCRIPTION
The `index.js` file got pretty big over time. This commit splits it into smaller modules:
- The core logic remains in `index.js`
- The `munge` functions are moved to the `lib/munge` directory. Each module detects and wraps one kind of target.
- Helper functions are moved out of `index.js` to the `lib` directory

Using multiple modules instead of a single `index.js` enables easier future extensions.