### PR TITLE
chore: Remove glob from tap command-line

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ sudo: false
 language: node_js
 
 node_js:
-  - '8'
-  - '10'
+#  - '8'
+#  - '10'
   - '12'
 
 os:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2874,9 +2874,9 @@
       "dev": true
     },
     "tap": {
-      "version": "13.1.10",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.10.tgz",
-      "integrity": "sha512-2TpQzzKsAViFR7V6QoSB3U3PeMzdliTczxQaTPZsEb8fbpSjp9vf3lajdHeLpHyqQEiU8v05Lf8o9lfg5n6VUw==",
+      "version": "13.1.11",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.11.tgz",
+      "integrity": "sha512-SgI0T/Na31XswviNA8tw0d71qOAZ1qjVMxpPO3XSW6372bVbz8pOR8ll2S4EnA+3yRfDSKN/rtj7gD+QjHJ2ow==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^1.1.0",
@@ -2888,7 +2888,7 @@
         "coveralls": "^3.0.3",
         "diff": "^4.0.1",
         "domain-browser": "^1.2.0",
-        "esm": "^3.2.22",
+        "esm": "^3.2.25",
         "findit": "^2.0.0",
         "foreground-child": "^1.3.3",
         "fs-exists-cached": "^1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -263,9 +263,9 @@
       "dev": true
     },
     "anymatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.1.tgz",
-      "integrity": "sha512-WQdpV5fo7XSY76HPN4pqdUl13Q282JsV0gQ8OnIxQsqDEHDZJCBkQ89fL1Mb3tNiPzGQnxMHM5G2iG3k9O6yng==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.0.2.tgz",
+      "integrity": "sha512-rUe9SxpRQlVg4EM8It7JMNWWYHAirTPpbTuvaSKybb5IejNgWB3PGBBX9rrPKDx2pM/p3Wh+7+ASaWRyyAbxmQ==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0",
@@ -1038,9 +1038,9 @@
       "dev": true
     },
     "esm": {
-      "version": "3.2.22",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.22.tgz",
-      "integrity": "sha512-z8YG7U44L82j1XrdEJcqZOLUnjxco8pO453gKOlaMD1/md1n/5QrscAmYG+oKUspsmDLuBFZrpbxI6aQ67yRxA==",
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
       "dev": true
     },
     "esprima": {
@@ -1188,9 +1188,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.6.tgz",
-      "integrity": "sha512-vfmKZp3XPM36DNF0qhW+Cdxk7xm7gTEHY1clv1Xq1arwRQuKZgAhw+NZNWbJBtuaNxzNXwhfdPYRrvIbjfS33A==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.0.7.tgz",
+      "integrity": "sha512-a7YT0SV3RB+DjYcppwVDLtn13UQnmg0SWZS7ezZD0UjnLwXmy8Zm21GMVGLaFGimIqcvyMQaOJBrop8MyOp1kQ==",
       "dev": true,
       "optional": true
     },
@@ -1700,9 +1700,9 @@
       }
     },
     "istanbul-reports": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.4.tgz",
-      "integrity": "sha512-QCHGyZEK0bfi9GR215QSm+NJwFKEShbtc7tfbUdLAEzn3kKhLDDZqvljn8rPZM9v8CEOhzL1nlYoO4r1ryl67w==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-2.2.6.tgz",
+      "integrity": "sha512-SKi4rnMyLBKe0Jy2uUdx28h8oG7ph2PPuQPvIAh31d+Ci+lSiEu4C+h3oBPuJ9+mPKhOyW0M8gY4U5NM1WLeXA==",
       "dev": true,
       "requires": {
         "handlebars": "^4.1.2"
@@ -2338,9 +2338,9 @@
       "dev": true
     },
     "picomatch": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.6.tgz",
-      "integrity": "sha512-Btng9qVvFsW6FkXYQQK5nEI5i8xdXFDmlKxC7Q8S2Bu5HGWnbQf7ts2kOoxJIrZn5hmw61RZIayAg2zBuJDtyQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.0.7.tgz",
+      "integrity": "sha512-oLHIdio3tZ0qH76NybpeneBhYVj0QFTfXEFTc/B3zKQspYfYYkWYgFsmzo+4kvId/bQRcNkVeguI3y+CD22BtA==",
       "dev": true
     },
     "pify": {
@@ -2565,9 +2565,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -2849,9 +2849,9 @@
       "dev": true
     },
     "tap": {
-      "version": "13.1.8",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.8.tgz",
-      "integrity": "sha512-WimjKgEZPOxSufS6Vfo/ACQmfMdLGmrIi9ZL6Q1mZpHcbdnBP4DgdIJWM+PKrLS4sbrIN2trKKlNO0QkziE1EQ==",
+      "version": "13.1.10",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.10.tgz",
+      "integrity": "sha512-2TpQzzKsAViFR7V6QoSB3U3PeMzdliTczxQaTPZsEb8fbpSjp9vf3lajdHeLpHyqQEiU8v05Lf8o9lfg5n6VUw==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^1.1.0",
@@ -3123,9 +3123,9 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "3.5.12",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.12.tgz",
-      "integrity": "sha512-KeQesOpPiZNgVwJj8Ge3P4JYbQHUdZzpx6Fahy6eKAYRSV4zhVmLXoC+JtOeYxcHCHTve8RG1ZGdTvpeOUM26Q==",
+      "version": "3.5.13",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.13.tgz",
+      "integrity": "sha512-Lho+IJlquX6sdJgyKSJx/M9y4XbDd3ekPjD8S6HYmT5yVSwDtlSuca2w5hV4g2dIsp0Y/4orbfWxKexodmFv7w==",
       "dev": true,
       "optional": true,
       "requires": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -916,6 +916,31 @@
         "safe-buffer": "^5.0.1"
       }
     },
+    "cross-env": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-5.2.0.tgz",
+      "integrity": "sha512-jtdNFfFW1hB7sMhr/H6rW1Z45LFqyI431m3qU6bFXcQ3Eh7LtBuG3h74o7ohHZ3crrRkkqHlo4jYHFPcjroANg==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^6.0.5",
+        "is-windows": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "6.0.5",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+          "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+          "dev": true,
+          "requires": {
+            "nice-try": "^1.0.4",
+            "path-key": "^2.0.1",
+            "semver": "^5.5.0",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "which": "^1.3.0"
   },
   "scripts": {
-    "test": "tap",
+    "test": "cross-env NODE_DEBUG=tap tap",
     "preversion": "npm test",
     "postversion": "npm publish",
     "postpublish": "git push origin --all; git push origin --tags",
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/istanbuljs/spawn-wrap#readme",
   "devDependencies": {
+    "cross-env": "^5.2.0",
     "tap": "^13.1.10"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/istanbuljs/spawn-wrap#readme",
   "devDependencies": {
     "cross-env": "^5.2.0",
-    "tap": "^13.1.10"
+    "tap": "^13.1.11"
   },
   "files": [
     "lib/",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "which": "^1.3.0"
   },
   "scripts": {
-    "test": "tap \"test/*.js\"",
+    "test": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
     "postpublish": "git push origin --all; git push origin --tags",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/istanbuljs/spawn-wrap#readme",
   "devDependencies": {
-    "tap": "^13.1.6"
+    "tap": "^13.1.10"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
Update to tap@13.1.10 to fix a bug where command-line glob was required
under Windows.