### PR TITLE
chore: Remove glob from tap command-line

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1791,9 +1791,9 @@
       }
     },
     "jackspeak": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.3.7.tgz",
-      "integrity": "sha512-Z4iSFpaCV7Cocpcl5t9/UyPkisxenbmaqminyTgK6lDDMXcm9EvIZ9Bwr/uFbGOjfWlz1UZwKwFY5AvtgNlHuw==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-1.3.8.tgz",
+      "integrity": "sha512-/Q7j4mWr5/XCnsR6IGA4FFZTylZCDbF5sNaLEVhfOYlau3DXcCSygTvXKnP3apwikzMirljf2QZq9fVuSZw6MA==",
       "dev": true,
       "requires": {
         "cliui": "^4.1.0"
@@ -2970,9 +2970,9 @@
       "dev": true
     },
     "tap": {
-      "version": "13.1.10",
-      "resolved": "https://registry.npmjs.org/tap/-/tap-13.1.10.tgz",
-      "integrity": "sha512-2TpQzzKsAViFR7V6QoSB3U3PeMzdliTczxQaTPZsEb8fbpSjp9vf3lajdHeLpHyqQEiU8v05Lf8o9lfg5n6VUw==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/tap/-/tap-14.0.0.tgz",
+      "integrity": "sha512-4690TGCbBTwyIhJWH918o/1zLoWUqc+8o0/zQtLjFLzQ76vlurNtMfVLkVS9dNztjuv01fgol+YhNJbzg/dfUA==",
       "dev": true,
       "requires": {
         "async-hook-domain": "^1.1.0",
@@ -2984,7 +2984,7 @@
         "coveralls": "^3.0.3",
         "diff": "^4.0.1",
         "domain-browser": "^1.2.0",
-        "esm": "^3.2.22",
+        "esm": "^3.2.25",
         "findit": "^2.0.0",
         "foreground-child": "^1.3.3",
         "fs-exists-cached": "^1.0.0",
@@ -2993,7 +2993,7 @@
         "import-jsx": "^2.0.0",
         "isexe": "^2.0.0",
         "istanbul-lib-processinfo": "^1.0.0",
-        "jackspeak": "^1.3.7",
+        "jackspeak": "^1.3.8",
         "minipass": "^2.3.5",
         "mkdirp": "^0.5.1",
         "nyc": "^14.1.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "which": "^1.3.0"
   },
   "scripts": {
-    "test": "tap \"test/*.js\"",
+    "test": "tap",
     "preversion": "npm test",
     "postversion": "npm publish",
     "postpublish": "git push origin --all; git push origin --tags",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/istanbuljs/spawn-wrap#readme",
   "devDependencies": {
-    "tap": "^13.1.6"
+    "tap": "^14.0.0"
   },
   "files": [
     "lib/",


### PR DESCRIPTION
Update to tap@14 to fix a bug where command-line glob was required
under Travis for Windows.