### PR TITLE
docs: Add JsDoc comments to munge functions

### DIFF
--- a/lib/munge.js
+++ b/lib/munge.js
@@ -9,6 +9,55 @@ const mungeNpm = require("./mungers/npm")
 const mungeSh = require("./mungers/sh")
 const mungeShebang = require("./mungers/shebang")
 
+/**
+ * @typedef {object} InternalSpawnOptions Options for the internal spawn functions
+ *   `childProcess.ChildProcess.prototype.spawn` and `process.binding('spawn_sync').spawn`.
+ *   These are the options mapped by the `munge` function to intercept spawned processes and
+ *   handle the wrapping logic.
+ *
+ * @property {string} file File to execute: either an absolute system-dependent path or a
+ *   command name.
+ * @property {string[]} args Command line arguments passed to the spawn process, including argv0.
+ * @property {string | undefined} cwd Optional path to the current working directory passed to the
+ *   spawned process. Default: `process.cwd()`
+ * @property {boolean} windowsHide Boolean controlling if the process should be spawned as
+ *   hidden (no GUI) on Windows.
+ * @property {boolean} windowsVerbatimArguments Boolean controlling if Node should preprocess
+ *   the CLI arguments on Windows.
+ * @property {boolean} detached Boolean controlling if the child process should keep its parent
+ *   alive or not.
+ * @property {string[]} envPairs Array of serialized environment variable key/value pairs. The
+ *   variables serialized as `key + "=" + value`.
+ * @property {import("child_process").StdioOptions} stdio Stdio options, with the same semantics
+ *   as the `stdio` parameter from the public API.
+ * @property {number | undefined} uid User id for the spawn process, same as the `uid` parameter
+ *   from the public API.
+ * @property {number | undefined} gid Group id for the spawn process, same as the `gid` parameter
+ *   from the public API.
+ *
+ * @property {string | undefined} basename Custom property only used by `spawn-wrap`. It is the
+ *   basename of the file to spawn (so individual mungers don't have to duplicate the code to
+ *   compute it).
+ * @property {string | undefined} originalNode Custom property only used by `spawn-wrap`. It is
+ *   used to remember the original Node executable that was intended to be spawned by the user.
+ */
+
+/**
+ * Updates the internal spawn options to redirect the process through the shim and wrapper.
+ *
+ * This works on the options passed to `childProcess.ChildProcess.prototype.spawn` and
+ * `process.binding('spawn_sync').spawn`.
+ *
+ * This function works by trying to identify the spawn process and map the options accordingly.
+ * `spawn-wrap` recognizes most shells, Windows `cmd.exe`, Node and npm invocations; when spawn
+ * either directly or through a script with a shebang line.
+ * It also unconditionally updates the environment variables so bare `node` commands execute
+ * the shim script instead of Node's binary.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function munge(workingDir, options) {
   options.basename = path.basename(options.file).replace(/\.exe$/i, '')
 

--- a/lib/mungers/cmd.js
+++ b/lib/mungers/cmd.js
@@ -3,6 +3,13 @@
 const path = require("path")
 const whichOrUndefined = require("../which-or-undefined")
 
+/**
+ * Intercepts Node and npm processes spawned through Windows' `cmd.exe`.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeCmd(workingDir, options) {
   const cmdi = options.args.indexOf('/c')
   if (cmdi === -1) {

--- a/lib/mungers/env.js
+++ b/lib/mungers/env.js
@@ -7,6 +7,13 @@ const homedir = require("../homedir")
 const pathRe = isWindows() ? /^PATH=/i : /^PATH=/;
 const colon = isWindows() ? ';' : ':'
 
+/**
+ * Updates the environment variables to intercept `node` commands and pass down options.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeEnv(workingDir, options) {
   let pathEnv
   for (let i = 0; i < options.envPairs.length; i++) {

--- a/lib/mungers/node.js
+++ b/lib/mungers/node.js
@@ -4,6 +4,13 @@ const path = require('path')
 const {debug} = require("../debug")
 const whichOrUndefined = require("../which-or-undefined")
 
+/**
+ * Intercepts Node spawned processes.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeNode(workingDir, options) {
   options.originalNode = options.file
   const command = path.basename(options.file).replace(/\.exe$/i, '')

--- a/lib/mungers/npm.js
+++ b/lib/mungers/npm.js
@@ -4,6 +4,13 @@ const path = require("path")
 const {debug} = require("../debug")
 const whichOrUndefined = require("../which-or-undefined")
 
+/**
+ * Intercepts npm spawned processes.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeNpm(workingDir, options) {
   debug('munge npm')
   // XXX weird effects of replacing a specific npm with a global one

--- a/lib/mungers/sh.js
+++ b/lib/mungers/sh.js
@@ -6,6 +6,13 @@ const {debug} = require("../debug")
 const {isNode} = require("../exe-type")
 const whichOrUndefined = require("../which-or-undefined")
 
+/**
+ * Intercepts Node and npm processes spawned through a Linux shell.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeSh(workingDir, options) {
   const cmdi = options.args.indexOf('-c')
   if (cmdi === -1) {

--- a/lib/mungers/shebang.js
+++ b/lib/mungers/shebang.js
@@ -5,6 +5,13 @@ const path = require("path")
 const {isNode} = require("../exe-type")
 const whichOrUndefined = require("../which-or-undefined")
 
+/**
+ * Intercepts processes spawned through a script with a shebang line.
+ *
+ * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
+ * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
+ * @return {void} This function does not return any value, the options are modified in-place.
+ */
 function mungeShebang(workingDir, options) {
   const resolved = whichOrUndefined(options.file)
   if (resolved === undefined) {


### PR DESCRIPTION
This commit documents the `InternalSpawOptions` objects manipulated by the munge functions.