### PR TITLE
fix: Make munge functions pure

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,9 +54,9 @@ function wrappedSpawnFunction (fn, workingDir) {
   return wrappedSpawn
 
   function wrappedSpawn (options) {
-    munge(workingDir, options)
-    debug('WRAPPED', options)
-    return fn.call(this, options)
+    const mungedOptions = munge(workingDir, options)
+    debug('WRAPPED', mungedOptions)
+    return fn.call(this, mungedOptions)
   }
 }
 

--- a/lib/exe-type.js
+++ b/lib/exe-type.js
@@ -23,9 +23,29 @@ function isSh(file) {
   return ['dash', 'sh', 'bash', 'zsh'].includes(file)
 }
 
+/**
+ * Returns the basename of the executable.
+ *
+ * On Windows, strips the `.exe` extension (if any) and normalizes the name to
+ * lowercase.
+ *
+ * @param exePath {string} Path of the executable as passed to spawned processes:
+ *   either command or a path to a file.
+ * @return {string} Basename of the executable.
+ */
+function getExeBasename(exePath) {
+  const baseName = path.basename(exePath);
+  if (isWindows()) {
+    return baseName.replace(/\.exe$/i, "").toLowerCase();
+  } else {
+    return baseName;
+  }
+}
+
 module.exports = {
   isCmd,
   isNode,
   isNpm,
   isSh,
+  getExeBasename,
 }

--- a/lib/exe-type.js
+++ b/lib/exe-type.js
@@ -36,6 +36,8 @@ function isSh(file) {
 function getExeBasename(exePath) {
   const baseName = path.basename(exePath);
   if (isWindows()) {
+    // Stripping `.exe` seems to be enough for our usage. We may eventually
+    // want to handle all executable extensions (such as `.bat` or `.cmd`).
     return baseName.replace(/\.exe$/i, "").toLowerCase();
   } else {
     return baseName;

--- a/lib/munge.js
+++ b/lib/munge.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const path = require("path")
-const {isCmd, isNode, isNpm, isSh} = require("./exe-type")
+const {isCmd, isNode, isNpm, isSh, getExeBasename} = require("./exe-type")
 const mungeCmd = require("./mungers/cmd")
 const mungeEnv = require("./mungers/env")
 const mungeNode = require("./mungers/node")
@@ -35,15 +34,12 @@ const mungeShebang = require("./mungers/shebang")
  * @property {number | undefined} gid Group id for the spawn process, same as the `gid` parameter
  *   from the public API.
  *
- * @property {string | undefined} basename Custom property only used by `spawn-wrap`. It is the
- *   basename of the file to spawn (so individual mungers don't have to duplicate the code to
- *   compute it).
  * @property {string | undefined} originalNode Custom property only used by `spawn-wrap`. It is
  *   used to remember the original Node executable that was intended to be spawned by the user.
  */
 
 /**
- * Updates the internal spawn options to redirect the process through the shim and wrapper.
+ * Returns updated internal spawn options to redirect the process through the shim and wrapper.
  *
  * This works on the options passed to `childProcess.ChildProcess.prototype.spawn` and
  * `process.binding('spawn_sync').spawn`.
@@ -55,24 +51,24 @@ const mungeShebang = require("./mungers/shebang")
  * the shim script instead of Node's binary.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {InternalSpawnOptions} Original internal spawn options.
+ * @return {InternalSpawnOptions} Updated internal spawn options.
  */
 function munge(workingDir, options) {
-  options.basename = path.basename(options.file).replace(/\.exe$/i, '')
+  const basename = getExeBasename(options.file);
 
   // XXX: dry this
-  if (isSh(options.basename)) {
-    mungeSh(workingDir, options)
-  } else if (isCmd(options.basename)) {
-    mungeCmd(workingDir, options)
-  } else if (isNode(options.basename)) {
-    mungeNode(workingDir, options)
-  } else if (isNpm(options.basename)) {
+  if (isSh(basename)) {
+    options = mungeSh(workingDir, options)
+  } else if (isCmd(basename)) {
+    options = mungeCmd(workingDir, options)
+  } else if (isNode(basename)) {
+    options = mungeNode(workingDir, options)
+  } else if (isNpm(basename)) {
     // XXX unnecessary?  on non-windows, npm is just another shebang
-    mungeNpm(workingDir, options)
+    options = mungeNpm(workingDir, options)
   } else {
-    mungeShebang(workingDir, options)
+    options = mungeShebang(workingDir, options)
   }
 
   // now the options are munged into shape.
@@ -80,7 +76,9 @@ function munge(workingDir, options) {
   // so that if a script somewhere calls `node foo`, it gets our
   // wrapper instead.
 
-  mungeEnv(workingDir, options)
+  options = mungeEnv(workingDir, options)
+
+  return options
 }
 
 module.exports = munge

--- a/lib/mungers/cmd.js
+++ b/lib/mungers/cmd.js
@@ -13,7 +13,7 @@ const whichOrUndefined = require("../which-or-undefined")
 function mungeCmd(workingDir, options) {
   const cmdi = options.args.indexOf('/c')
   if (cmdi === -1) {
-    return options
+    return {...options}
   }
 
   const re = /^\s*("*)([^"]*?\bnode(?:\.exe|\.EXE)?)("*)( .*)?$/
@@ -21,7 +21,7 @@ function mungeCmd(workingDir, options) {
 
   const command = options.args[cmdi + 1]
   if (command === undefined) {
-    return options
+    return {...options}
   }
 
   let newArgs = [...options.args];
@@ -42,7 +42,7 @@ function mungeCmd(workingDir, options) {
     // npm, then the dirname will not work properly!
     m = command.match(npmre)
     if (m === null) {
-      return
+      return {...options}
     }
 
     let npmPath = whichOrUndefined('npm') || 'npm'

--- a/lib/mungers/cmd.js
+++ b/lib/mungers/cmd.js
@@ -7,13 +7,13 @@ const whichOrUndefined = require("../which-or-undefined")
  * Intercepts Node and npm processes spawned through Windows' `cmd.exe`.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeCmd(workingDir, options) {
   const cmdi = options.args.indexOf('/c')
   if (cmdi === -1) {
-    return
+    return options
   }
 
   const re = /^\s*("*)([^"]*?\bnode(?:\.exe|\.EXE)?)("*)( .*)?$/
@@ -21,16 +21,20 @@ function mungeCmd(workingDir, options) {
 
   const command = options.args[cmdi + 1]
   if (command === undefined) {
-    return
+    return options
   }
+
+  let newArgs = [...options.args];
+  // Remember the original Node command to use it in the shim
+  let originalNode;
 
   let m = command.match(re)
   let replace
   if (m) {
-    options.originalNode = m[2]
+    originalNode = m[2]
     // TODO: Remove `replace`: seems unused
     replace = m[1] + workingDir + '/node.cmd' + m[3] + m[4]
-    options.args[cmdi + 1] = m[1] + m[2] + m[3] +
+    newArgs[cmdi + 1] = m[1] + m[2] + m[3] +
       ' "' + workingDir + '\\node"' + m[4]
   } else {
     // XXX probably not a good idea to rewrite to the first npm in the
@@ -46,8 +50,10 @@ function mungeCmd(workingDir, options) {
     replace = m[1] + workingDir + '/node.cmd' +
       ' "' + npmPath + '"' +
       m[3] + m[4]
-    options.args[cmdi + 1] = command.replace(npmre, replace)
+    newArgs[cmdi + 1] = command.replace(npmre, replace)
   }
+
+  return {...options, args: newArgs, originalNode};
 }
 
 module.exports = mungeCmd

--- a/lib/mungers/env.js
+++ b/lib/mungers/env.js
@@ -11,32 +11,36 @@ const colon = isWindows() ? ';' : ':'
  * Updates the environment variables to intercept `node` commands and pass down options.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeEnv(workingDir, options) {
+  const newEnvPairs = [...options.envPairs];
+
   let pathEnv
   for (let i = 0; i < options.envPairs.length; i++) {
     const ep = options.envPairs[i]
     if (pathRe.test(ep)) {
       pathEnv = ep.substr(5)
       const k = ep.substr(0, 5)
-      options.envPairs[i] = k + workingDir + colon + pathEnv
+      newEnvPairs[i] = k + workingDir + colon + pathEnv
     }
   }
   if (pathEnv === undefined) {
-    options.envPairs.push((isWindows() ? 'Path=' : 'PATH=') + workingDir)
+    newEnvPairs.push((isWindows() ? 'Path=' : 'PATH=') + workingDir)
   }
   if (options.originalNode) {
     const key = path.basename(workingDir).substr('.node-spawn-wrap-'.length)
-    options.envPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
+    newEnvPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
   }
 
-  options.envPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
+  newEnvPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
 
   if (process.env.SPAWN_WRAP_DEBUG === '1') {
-    options.envPairs.push('SPAWN_WRAP_DEBUG=1')
+    newEnvPairs.push('SPAWN_WRAP_DEBUG=1')
   }
+
+  return {...options, envPairs: newEnvPairs};
 }
 
 module.exports = mungeEnv

--- a/lib/mungers/env.js
+++ b/lib/mungers/env.js
@@ -15,32 +15,36 @@ const colon = isWindows() ? ';' : ':'
  * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeEnv(workingDir, options) {
-  const newEnvPairs = [...options.envPairs];
-
   let pathEnv
-  for (let i = 0; i < options.envPairs.length; i++) {
-    const ep = options.envPairs[i]
+
+  const envPairs = options.envPairs.map((ep) => {
     if (pathRe.test(ep)) {
+      // `PATH` env var: prefix its value with `workingDir`
+      // `5` corresponds to the length of `PATH=`
       pathEnv = ep.substr(5)
       const k = ep.substr(0, 5)
-      newEnvPairs[i] = k + workingDir + colon + pathEnv
+      return k + workingDir + colon + pathEnv
+    } else {
+      // Return as-is
+      return ep;
     }
-  }
+  });
+
   if (pathEnv === undefined) {
-    newEnvPairs.push((isWindows() ? 'Path=' : 'PATH=') + workingDir)
+    envPairs.push((isWindows() ? 'Path=' : 'PATH=') + workingDir)
   }
   if (options.originalNode) {
     const key = path.basename(workingDir).substr('.node-spawn-wrap-'.length)
-    newEnvPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
+    envPairs.push('SW_ORIG_' + key + '=' + options.originalNode)
   }
 
-  newEnvPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
+  envPairs.push('SPAWN_WRAP_SHIM_ROOT=' + homedir)
 
   if (process.env.SPAWN_WRAP_DEBUG === '1') {
-    newEnvPairs.push('SPAWN_WRAP_DEBUG=1')
+    envPairs.push('SPAWN_WRAP_DEBUG=1')
   }
 
-  return {...options, envPairs: newEnvPairs};
+  return {...options, envPairs};
 }
 
 module.exports = mungeEnv

--- a/lib/mungers/node.js
+++ b/lib/mungers/node.js
@@ -2,17 +2,20 @@
 
 const path = require('path')
 const {debug} = require("../debug")
+const {getExeBasename} = require("../exe-type")
 const whichOrUndefined = require("../which-or-undefined")
 
 /**
  * Intercepts Node spawned processes.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeNode(workingDir, options) {
-  options.originalNode = options.file
+  // Remember the original Node command to use it in the shim
+  const originalNode = options.file
+
   const command = path.basename(options.file).replace(/\.exe$/i, '')
   // make sure it has a main script.
   // otherwise, just let it through.
@@ -49,9 +52,12 @@ function mungeNode(workingDir, options) {
     }
   }
 
+  const newArgs = [...options.args];
+  let newFile = options.file;
+
   if (hasMain) {
     const replace = workingDir + '/' + command
-    options.args.splice(mainIndex, 0, replace)
+    newArgs.splice(mainIndex, 0, replace)
   }
 
   // If the file is just something like 'node' then that'll
@@ -59,12 +65,15 @@ function mungeNode(workingDir, options) {
   // to resolve that here first.
   // This also handles the case where there's not a main file, like
   // `node -e 'program'`, where we want to avoid the shim entirely.
-  if (options.file === options.basename) {
+  if (options.file === getExeBasename(options.file)) {
     const realNode = whichOrUndefined(options.file) || process.execPath
-    options.file = options.args[0] = realNode
+    newArgs[0] = realNode
+    newFile = realNode
   }
 
   debug('mungeNode after', options.file, options.args)
+
+  return {...options, file: newFile, args: newArgs, originalNode};
 }
 
 module.exports = mungeNode

--- a/lib/mungers/node.js
+++ b/lib/mungers/node.js
@@ -16,7 +16,7 @@ function mungeNode(workingDir, options) {
   // Remember the original Node command to use it in the shim
   const originalNode = options.file
 
-  const command = path.basename(options.file).replace(/\.exe$/i, '')
+  const command = getExeBasename(options.file)
   // make sure it has a main script.
   // otherwise, just let it through.
   let a = 0
@@ -65,7 +65,7 @@ function mungeNode(workingDir, options) {
   // to resolve that here first.
   // This also handles the case where there's not a main file, like
   // `node -e 'program'`, where we want to avoid the shim entirely.
-  if (options.file === getExeBasename(options.file)) {
+  if (options.file === command) {
     const realNode = whichOrUndefined(options.file) || process.execPath
     newArgs[0] = realNode
     newFile = realNode

--- a/lib/mungers/npm.js
+++ b/lib/mungers/npm.js
@@ -8,21 +8,25 @@ const whichOrUndefined = require("../which-or-undefined")
  * Intercepts npm spawned processes.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeNpm(workingDir, options) {
   debug('munge npm')
   // XXX weird effects of replacing a specific npm with a global one
   const npmPath = whichOrUndefined('npm')
 
-  if (npmPath !== undefined) {
-    options.args[0] = npmPath
-
-    const file = path.join(workingDir, 'node')
-    options.file = file
-    options.args.unshift(file)
+  if (npmPath === undefined) {
+    return options;
   }
+
+  const newArgs = [...options.args]
+
+  newArgs[0] = npmPath
+  const file = path.join(workingDir, 'node')
+  newArgs.unshift(file)
+
+  return {...options, file, args: newArgs}
 }
 
 module.exports = mungeNpm

--- a/lib/mungers/npm.js
+++ b/lib/mungers/npm.js
@@ -17,7 +17,7 @@ function mungeNpm(workingDir, options) {
   const npmPath = whichOrUndefined('npm')
 
   if (npmPath === undefined) {
-    return options;
+    return {...options};
   }
 
   const newArgs = [...options.args]

--- a/lib/mungers/sh.js
+++ b/lib/mungers/sh.js
@@ -16,14 +16,14 @@ const whichOrUndefined = require("../which-or-undefined")
 function mungeSh(workingDir, options) {
   const cmdi = options.args.indexOf('-c')
   if (cmdi === -1) {
-    return options // no -c argument
+    return {...options} // no -c argument
   }
 
   let c = options.args[cmdi + 1]
   const re = /^\s*((?:[^\= ]*\=[^\=\s]*)*[\s]*)([^\s]+|"[^"]+"|'[^']+')( .*)?$/
   const match = c.match(re)
   if (match === null) {
-    return options // not a command invocation.  weird but possible
+    return {...options} // not a command invocation.  weird but possible
   }
 
   let command = match[2]

--- a/lib/mungers/sh.js
+++ b/lib/mungers/sh.js
@@ -10,20 +10,20 @@ const whichOrUndefined = require("../which-or-undefined")
  * Intercepts Node and npm processes spawned through a Linux shell.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeSh(workingDir, options) {
   const cmdi = options.args.indexOf('-c')
   if (cmdi === -1) {
-    return // no -c argument
+    return options // no -c argument
   }
 
   let c = options.args[cmdi + 1]
   const re = /^\s*((?:[^\= ]*\=[^\=\s]*)*[\s]*)([^\s]+|"[^"]+"|'[^']+')( .*)?$/
   const match = c.match(re)
   if (match === null) {
-    return // not a command invocation.  weird but possible
+    return options // not a command invocation.  weird but possible
   }
 
   let command = match[2]
@@ -34,10 +34,14 @@ function mungeSh(workingDir, options) {
   }
   const exe = path.basename(command)
 
+  let newArgs = [...options.args];
+  // Remember the original Node command to use it in the shim
+  let originalNode;
+
   if (isNode(exe)) {
-    options.originalNode = command
+    originalNode = command
     c = match[1] + match[2] + ' "' + workingDir + '/node" ' + match[3]
-    options.args[cmdi + 1] = c
+    newArgs[cmdi + 1] = c
   } else if (exe === 'npm' && !isWindows()) {
     // XXX this will exhibit weird behavior when using /path/to/npm,
     // if some other npm is first in the path.
@@ -45,10 +49,12 @@ function mungeSh(workingDir, options) {
 
     if (npmPath) {
       c = c.replace(re, '$1 "' + workingDir + '/node" "' + npmPath + '" $3')
-      options.args[cmdi + 1] = c
+      newArgs[cmdi + 1] = c
       debug('npm munge!', c)
     }
   }
+
+  return {...options, args: newArgs, originalNode};
 }
 
 module.exports = mungeSh

--- a/lib/mungers/shebang.js
+++ b/lib/mungers/shebang.js
@@ -15,19 +15,19 @@ const whichOrUndefined = require("../which-or-undefined")
 function mungeShebang(workingDir, options) {
   const resolved = whichOrUndefined(options.file)
   if (resolved === undefined) {
-    return options
+    return {...options}
   }
 
   const shebang = fs.readFileSync(resolved, 'utf8')
   const match = shebang.match(/^#!([^\r\n]+)/)
   if (!match) {
-    return options // not a shebang script, probably a binary
+    return {...options} // not a shebang script, probably a binary
   }
 
   const shebangbin = match[1].split(' ')[0]
   const maybeNode = path.basename(shebangbin)
   if (!isNode(maybeNode)) {
-    return options // not a node shebang, leave untouched
+    return {...options} // not a node shebang, leave untouched
   }
 
   const originalNode = shebangbin

--- a/lib/mungers/shebang.js
+++ b/lib/mungers/shebang.js
@@ -9,34 +9,35 @@ const whichOrUndefined = require("../which-or-undefined")
  * Intercepts processes spawned through a script with a shebang line.
  *
  * @param workingDir {string} Absolute system-dependent path to the directory containing the shim files.
- * @param options {import("../munge").InternalSpawnOptions} Internal spawn options to update.
- * @return {void} This function does not return any value, the options are modified in-place.
+ * @param options {import("../munge").InternalSpawnOptions} Original internal spawn options.
+ * @return {import("../munge").InternalSpawnOptions} Updated internal spawn options.
  */
 function mungeShebang(workingDir, options) {
   const resolved = whichOrUndefined(options.file)
   if (resolved === undefined) {
-    return
+    return options
   }
 
   const shebang = fs.readFileSync(resolved, 'utf8')
   const match = shebang.match(/^#!([^\r\n]+)/)
   if (!match) {
-    return // not a shebang script, probably a binary
+    return options // not a shebang script, probably a binary
   }
 
   const shebangbin = match[1].split(' ')[0]
   const maybeNode = path.basename(shebangbin)
   if (!isNode(maybeNode)) {
-    return // not a node shebang, leave untouched
+    return options // not a node shebang, leave untouched
   }
 
-  options.originalNode = shebangbin
-  options.basename = maybeNode
-  options.file = shebangbin
-  options.args = [shebangbin, workingDir + '/' + maybeNode]
+  const originalNode = shebangbin
+  const file = shebangbin
+  const args = [shebangbin, workingDir + '/' + maybeNode]
     .concat(resolved)
     .concat(match[1].split(' ').slice(1))
     .concat(options.args.slice(1))
+
+  return {...options, file, args, originalNode};
 }
 
 module.exports = mungeShebang


### PR DESCRIPTION
This commit updates the munge functions to no longer update the options object in place but return the updated options. If the options are not modified, it may return the input options directly (**Edit**: changed following a comment on one of the commits: the result is always a new object).

This allows better isolation of the munge functions so they are easier to verify.

As part of this change, the mungers no longer set the custom field `basename` on the options object. It was previously used as an indirect way to pass data between the `shebang` and `node` mungers. It got replaced by a standalone function to retrieve the basename from the file.

/cc @coreyfarrell 