### PR TITLE
fix(win32): handle cases where "node" is quoted

### DIFF
--- a/index.js
+++ b/index.js
@@ -417,8 +417,13 @@ function setup (argv, env) {
     var cmdShim =
       '@echo off\r\n' +
       'SETLOCAL\r\n' +
+      'CALL :find_dp0\r\n' +
       'SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
-      '"' + process.execPath + '"' + ' "%~dp0\\.\\node" %*\r\n'
+      '"' + process.execPath + '"' + ' "%dp0%node" %*\r\n' +
+      'EXIT /b %errorlevel%\r\n'+
+      ':find_dp0\r\n' +
+      'SET dp0=%~dp0\r\n' +
+      'EXIT /b\r\n'
 
     fs.writeFileSync(workingDir + '/node.cmd', cmdShim)
     fs.chmodSync(workingDir + '/node.cmd', '0755')


### PR DESCRIPTION
This fixes an issue which was triggered by npm v6.11, where the
"program" referenced by a shimmed shebang is always quoted (whereas
before, it would not be).  Ironically, the code change in npm was to
work around cases where a user puts `"jslint"` in a batch file,
resulting in the wrong %~dp0 being loaded.  The fix triggered the same
behavior in NYC, and the same fix resolves the problem here.

For arcane and mysterious reasons, calling a subroutine in a batch file
causes the %~dp0 variable to be set properly.