### PR TITLE
Fix no coverage with globally installed testers on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,6 +147,24 @@ function setup(argv, env) {
     fs.writeFileSync(path.join(workingDir, cmdname), shim)
     fs.chmodSync(path.join(workingDir, cmdname), '0755')
   }
+  else if (cmdname === 'node') {
+    const nodePath = path.dirname(process.execPath)
+    const cmds = JSON.parse(env.NYC_CONFIG)._
+    cmds.forEach((cmd) => {
+      const filepath = path.resolve(nodePath, cmd)
+      if (fs.existsSync(filepath + '.cmd')) {
+        const batch = fs.readFileSync(filepath + '.cmd', 'utf8')
+        const shell = fs.readFileSync(filepath, 'utf8')
+        const powershell = fs.readFileSync(filepath + '.ps1', 'utf8')
+        fs.writeFileSync(workingDir + '/' + cmd + '.cmd', batch.replace('"%_prog%"  "%dp0%', '"%_prog%"  "' + nodePath))
+        fs.chmodSync(workingDir + '/' + cmd + '.cmd', '0755')
+        fs.writeFileSync(workingDir + '/' + cmd, shell.replace('"$basedir/node"  "$basedir', '"$basedir/node"  "' + nodePath))
+        fs.chmodSync(workingDir + '/' + cmd, '0755')
+        fs.writeFileSync(workingDir + '/' + cmd + '.ps1', powershell.replace('node$exe"  "$basedir', 'node$exe"  "' + nodePath))
+        fs.chmodSync(workingDir + '/' + cmd + '.ps1', '0755')
+      }
+    })
+  }
   fs.writeFileSync(path.join(workingDir, 'settings.json'), settings)
 
   return workingDir


### PR DESCRIPTION
This is a try on fixing the bug where nyc does not report coverage data when the test runners are installed globally on Windows. This fixes [#1029 on nyc repo](https://github.com/istanbuljs/nyc/issues/1029).

As I explained on the nyc issue, on Windows the modules "executables" are `*.cmd` files that check if the node executable is under the same directory and if so they use it instead of the one in PATH.

My solution is to copy those scripts (batch/shell/powershell) to the same temporary directory you guys already use for the node script and modify them to point to their correct module paths. Honestly I fear this solution is too dirty and not fail proof, but has worked fine with both [AVA](https://github.com/avajs/ava) and [mocha](https://github.com/mochajs/mocha).

I have tested with `cmd` and `MSYS2/Mintty`. I have not tested with local installations of the testers.

CC: @bcoe