### PR TITLE
[DO NOT LAND] Merge 1.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.4.3](https://github.com/isaacs/spawn-wrap/compare/v1.4.2...v1.4.3) (2019-08-23)
+
+
+### Bug Fixes
+
+* **win32:** handle cases where "node" is quoted ([#102](https://github.com/isaacs/spawn-wrap/issues/102)) ([aac8730](https://github.com/isaacs/spawn-wrap/commit/aac8730))

--- a/index.js
+++ b/index.js
@@ -134,8 +134,13 @@ function setup(argv, env) {
     const cmdShim =
       '@echo off\r\n' +
       'SETLOCAL\r\n' +
+      'CALL :find_dp0\r\n' +
       'SET PATHEXT=%PATHEXT:;.JS;=;%\r\n' +
       '"' + process.execPath + '" "%~dp0\\.\\node" %*\r\n'
+      'EXIT /b %errorlevel%\r\n'+
+      ':find_dp0\r\n' +
+      'SET dp0=%~dp0\r\n' +
+      'EXIT /b\r\n'
 
     fs.writeFileSync(path.join(workingDir, 'node.cmd'), cmdShim)
     fs.chmodSync(path.join(workingDir, 'node.cmd'), '0755')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-wrap",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spawn-wrap",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "description": "Wrap all spawned Node.js child processes by adding environs and arguments ahead of the main JavaScript file argument.",
   "main": "index.js",
   "engines": {


### PR DESCRIPTION
The intent is that `master` will be fast-forwarded to this branch with the merge commit to bring v1.4.3 into the master branch history.  The goal of this PR is to give @isaacs, @bcoe or Travis a chance to object to this.

@bcoe I ran `standard-version --dry-run`, it seemed to show the changelog entries I expected for 2.0.0.  Can you think of any issues here?